### PR TITLE
ci: update automatic PR labeling to GH default labels

### DIFF
--- a/.github/workflows/ci-basic.yaml
+++ b/.github/workflows/ci-basic.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: ytanikin/pr-conventional-commits@1.4.0
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          custom_labels: '{"feat": "enhancement", "fix": "bug", "docs": "documentation", "test": "test", "ci": "ci", "refactor": "refactor", "perf": "performance", "chore": "chore", "revert": "revert", "wip": "wip"}'
         if: github.event_name == 'pull_request'
 
   pnpm-lint:


### PR DESCRIPTION
We want to use already existing labels and not duplicate already existing labels.