### PR TITLE
ci: run language-specific pre-commit-hooks conditionally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
         name: run golangci-lint
         types: [go]
         language: system
-        entry: golangci-lint run backend
+        entry: golangci-lint run api-service
         pass_filenames: false
 
       - id: prettier-check


### PR DESCRIPTION
Adds `types` and `files` fields to pre-commit-hooks. 

Now, only relevant hooks run, i.e if only `go` code is changed, the `rust` hooks don't run. 