### PR TITLE
ci: fix failing 'changes' job

### DIFF
--- a/.github/workflows/ci-basic.yaml
+++ b/.github/workflows/ci-basic.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: read
+      contents: read
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       pnpm: ${{ steps.filter.outputs.pnpm }}


### PR DESCRIPTION
If a job runs on a PR, the `checkout` step is not needed. If the job runs on a branch, it requires that step.

This fixes the run failures on main, occurring albeit the runs inside the PR before succeeded.