### PR TITLE
fix(protobuf): allow all clippy categories

### DIFF
--- a/gen/proto_types/src/lib.rs
+++ b/gen/proto_types/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate protocheck;
 
+#[allow(clippy::all, clippy::pedantic, clippy::nursery)]
 pub mod job {
     pub mod v1 {
         include!("guggr.job.v1.rs");
@@ -11,6 +12,7 @@ pub mod job {
     }
 }
 
+#[allow(clippy::all, clippy::pedantic, clippy::nursery)]
 pub mod job_result {
     pub mod v1 {
         include!("guggr.job_result.v1.rs");


### PR DESCRIPTION
since those files are generated by protocheck, we can not change anything in there.

Therefore I decided to allow every category of clippy for those files, to clean up the output of `just bashme`.
This should help with developer experience, since we can now focus on the relevant clippy findings 😀