### PR TITLE
ci(actions): fix error when commit message contains single quote

### DIFF
--- a/.github/workflows/ci-basic.yaml
+++ b/.github/workflows/ci-basic.yaml
@@ -157,25 +157,42 @@ jobs:
         env:
           RUST_BACKTRACE: ${{ inputs.rustBacktrace || '0' }}
 
+  fetch-depth:
+    name: 🧮 calculate fetch depth
+    runs-on: ubuntu-24.04
+    outputs:
+      depth: ${{ steps.depth-push.outputs.depth || steps.depth-pr.outputs.depth }}
+      branch: ${{ steps.depth-push.outputs.branch || steps.depth-pr.outputs.branch }}
+    env:
+      COMMITS_JSON: ${{ toJson(github.event.commits) }}
+    steps:
+      - name: Set depth push
+        id: depth-push
+        shell: bash
+        if: github.event_name == 'push'
+        env:
+          COMMITS_JSON: ${{ toJson(github.event.commits) }}
+        run: |
+          COUNT=$(echo "$COMMITS_JSON" | jq 'length')
+          echo "depth=$((COUNT + 2))" >> $GITHUB_OUTPUT
+          echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+      - name: Set depth PR
+        id: depth-pr
+        shell: bash
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "depth=$((${{ github.event.pull_request.commits }}+2))" >> $GITHUB_OUTPUT
+          echo "branch=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
+
   trufflehog:
     name: 🔐 secret scanning
     runs-on: ubuntu-24.04
+    needs: fetch-depth
     steps:
-      - name: Calculate fetch depth
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            echo "depth=$(($(jq length <<< '${{ toJson(github.event.commits) }}') + 2))" >> $GITHUB_ENV
-            echo "branch=${{ github.ref_name }}" >> $GITHUB_ENV
-          fi
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "depth=$((${{ github.event.pull_request.commits }}+2))" >> $GITHUB_ENV
-            echo "branch=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
-          fi
       - uses: actions/checkout@v6.0.2
         with:
-          ref: ${{env.branch}}
-          fetch-depth: ${{env.depth}}
+          ref: ${{needs.fetch-depth.outputs.branch}}
+          fetch-depth: ${{needs.fetch-depth.outputs.depth}}
       - name: Secret Scanning
         uses: trufflesecurity/trufflehog@v3.93.3
         with:


### PR DESCRIPTION
This commit fixes an arbitrary code execution vulnerability in the trufflehog setup that caused a job failure during the merge of #46. Commit ae4a55d contained a single quote in its description.

Trufflehog's recommended shallow cloning is susceptible to an arbitrary code execution using single quotes. There are multiple open PRs to fix this issue in their README but those have not been merged yet. Trufflehog itself fixed the issue in their own CI via https://github.com/trufflesecurity/trufflehog/pull/2259.

Confer:
https://github.com/trufflesecurity/trufflehog#shallow-cloning
https://github.com/trufflesecurity/trufflehog/pull/2979
https://github.com/trufflesecurity/trufflehog/pull/4137
https://github.com/trufflesecurity/trufflehog/pulls?q=single+quote