### PR TITLE
ci(actions): delete cache on closed PR event

### DIFF
--- a/.github/workflows/cleanup_cache.yaml
+++ b/.github/workflows/cleanup_cache.yaml
@@ -1,0 +1,28 @@
+name: github runner cache cleanup
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+    steps:
+      - name: 🗑️ cleanup runner cache
+        run: |
+          echo "Fetching list of cache keys"
+          cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
+
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete $cacheKey
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge


### PR DESCRIPTION
We don't want to keep the PR's github runner cache when that PR was closed. 
This runs the cache clean up action when a PR is closed and deletes that PR's cache.


Action taken from: [github docs](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manage-caches).