### PR TITLE
ci(docker): add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/node_modules
+target


### PR DESCRIPTION
This was seemingly the issue why we couldn't build the frontend container consistently