### PR TITLE
fix(codeowners): minor syntax error

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-*               @guggr-dev
+*               @guggr/guggr-dev
 
 frontend/		@tametsi
 package.json	@tametsi


### PR DESCRIPTION
Issue was not visible before when the repository was private as the CODEOWNERS feature can't be activated for free there.