### PR TITLE
feat: add cleanup cron job for expired refresh tokens

### DIFF
--- a/scheduler/src/adapters/inbound/ticker.rs
+++ b/scheduler/src/adapters/inbound/ticker.rs
@@ -6,30 +6,30 @@ use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::{debug, info};
 
 use crate::core::{
-    domain::errors::JobSchedulerError, ports::ticker::Ticker,
-    service::schedulerservice::SchedulerService,
+    domain::errors::JobSchedulerError,
+    ports::{periodic_task::PeriodicTask, ticker::Ticker},
 };
 
 /// Struct for Ticker adapter. Holds its own task tracker for implementing
 /// graceful shutdown.
 pub struct SchedulerTicker {
-    service: Arc<SchedulerService>,
+    task: Arc<dyn PeriodicTask>,
     interval: Interval,
     task_tracker: TaskTracker,
     shutdown_token: CancellationToken,
 }
 
 impl SchedulerTicker {
-    /// Creates a new [`SchedulerTicker`] for running the service. Requires a
-    /// shutdown token for graceful shutdown.
+    /// Creates a new [`SchedulerTicker`] for running a periodic task. Requires
+    /// a shutdown token for graceful shutdown.
     #[must_use]
     pub fn new(
-        service: Arc<SchedulerService>,
+        task: Arc<dyn PeriodicTask>,
         run_every: Duration,
         shutdown_token: CancellationToken,
     ) -> Self {
         Self {
-            service,
+            task,
             interval: tokio::time::interval(run_every),
             task_tracker: TaskTracker::new(),
             shutdown_token,
@@ -41,7 +41,7 @@ impl SchedulerTicker {
 impl Ticker for SchedulerTicker {
     /// Starts the ticker with the defined interval.
     ///
-    /// - Spawns a new tokio task for running the service in the task pool for
+    /// - Spawns a new tokio task for running the task in the task pool for
     ///   each tick.
     /// - Handles graceful shutdown via the passed [`CancellationToken`].
     #[allow(clippy::ignored_unit_patterns)]
@@ -52,12 +52,12 @@ impl Ticker for SchedulerTicker {
         loop {
             tokio::select! {
                 _ = interval.tick() => {
-                    let service = Arc::clone(&self.service);
+                    let task = Arc::clone(&self.task);
 
-                    debug!("triggered service run in own task");
+                    debug!("triggered task run in own task");
                     self.task_tracker.spawn(async move {
-                        match service.run().await {
-                            Ok(()) => tracing::debug!("Batch processed successfully."),
+                        match task.run().await {
+                            Ok(()) => tracing::debug!("Task completed successfully."),
 
                             Err(JobSchedulerError::DatabaseUnavailable(e)) => {
                                 // We use WARN here because it's a transient infra issue
@@ -70,7 +70,7 @@ impl Ticker for SchedulerTicker {
                             }
 
                             Err(e) => {
-                                tracing::error!("Critical/Unknown error in service: {e}");
+                                tracing::error!("Critical/Unknown error in task: {e}");
                             }
                         }
                     });
@@ -85,9 +85,9 @@ impl Ticker for SchedulerTicker {
 
         self.task_tracker.close();
 
-        info!("Waiting for in-flight jobs to complete...");
+        info!("Waiting for in-flight tasks to complete...");
         self.task_tracker.wait().await;
 
-        info!("all jobs finished");
+        info!("all tasks finished");
     }
 }

--- a/scheduler/src/adapters/outbound/mod.rs
+++ b/scheduler/src/adapters/outbound/mod.rs
@@ -1,2 +1,3 @@
 pub mod postgres;
+pub mod postgres_token_cleaner;
 pub mod rabbitmq;

--- a/scheduler/src/adapters/outbound/postgres_token_cleaner.rs
+++ b/scheduler/src/adapters/outbound/postgres_token_cleaner.rs
@@ -1,0 +1,73 @@
+//! Postgres adapter for deleting expired refresh tokens.
+
+use async_trait::async_trait;
+use database_client::{DbError, schema::refresh_token};
+use diesel::{
+    PgConnection,
+    dsl::now,
+    prelude::*,
+    r2d2::{ConnectionManager, Pool},
+};
+use thiserror::Error;
+use tracing::debug;
+
+use crate::core::{domain::errors::JobSchedulerError, ports::token_cleaner::TokenCleaner};
+
+pub struct PostgresTokenCleaner {
+    pool: Pool<ConnectionManager<PgConnection>>,
+}
+
+#[derive(Error, Debug)]
+pub enum PostgresTokenCleanerError {
+    #[error("database connection failed: {0}")]
+    ConnectionError(#[from] DbError),
+    #[error("pool exhausted or timeout: {0}")]
+    PoolGetConnectionError(#[from] diesel::r2d2::PoolError),
+    #[error("failed to delete expired tokens: {0}")]
+    DeleteError(#[from] diesel::result::Error),
+}
+
+impl From<PostgresTokenCleanerError> for JobSchedulerError {
+    fn from(value: PostgresTokenCleanerError) -> Self {
+        match value {
+            PostgresTokenCleanerError::ConnectionError(e) => {
+                Self::DatabaseUnavailable(e.to_string())
+            }
+            PostgresTokenCleanerError::PoolGetConnectionError(e) => {
+                Self::DatabaseUnavailable(e.to_string())
+            }
+            other @ PostgresTokenCleanerError::DeleteError { .. } => {
+                Self::Internal(other.to_string())
+            }
+        }
+    }
+}
+
+impl PostgresTokenCleaner {
+    pub fn new(connection_url: &str) -> Result<Self, PostgresTokenCleanerError> {
+        let pool = database_client::create_connection_pool(connection_url)?;
+        Ok(Self { pool })
+    }
+
+    fn run_delete_query(&self) -> Result<usize, PostgresTokenCleanerError> {
+        debug!("getting db connection");
+        let mut conn = self.pool.get()?;
+
+        debug!("deleting expired refresh tokens");
+        let count = diesel::delete(refresh_token::table)
+            .filter(refresh_token::expires_on.lt(now))
+            .execute(&mut conn)?;
+
+        Ok(count)
+    }
+}
+
+#[async_trait]
+impl TokenCleaner for PostgresTokenCleaner {
+    async fn delete_expired_tokens(&self) -> Result<usize, JobSchedulerError> {
+        self.run_delete_query().map_err(|err| {
+            tracing::error!("database error: {:?}", err);
+            JobSchedulerError::from(err)
+        })
+    }
+}

--- a/scheduler/src/core/ports/mod.rs
+++ b/scheduler/src/core/ports/mod.rs
@@ -1,3 +1,5 @@
 pub mod job_fetcher;
+pub mod periodic_task;
 pub mod publisher;
 pub mod ticker;
+pub mod token_cleaner;

--- a/scheduler/src/core/ports/periodic_task.rs
+++ b/scheduler/src/core/ports/periodic_task.rs
@@ -1,0 +1,9 @@
+use async_trait::async_trait;
+
+use crate::core::domain::errors::JobSchedulerError;
+
+#[async_trait]
+pub trait PeriodicTask: Send + Sync {
+    /// Executes one tick of the periodic task.
+    async fn run(&self) -> Result<(), JobSchedulerError>;
+}

--- a/scheduler/src/core/ports/token_cleaner.rs
+++ b/scheduler/src/core/ports/token_cleaner.rs
@@ -1,0 +1,9 @@
+use async_trait::async_trait;
+
+use crate::core::domain::errors::JobSchedulerError;
+
+#[async_trait]
+pub trait TokenCleaner: Send + Sync {
+    /// Deletes all expired refresh tokens, returning the number of rows deleted.
+    async fn delete_expired_tokens(&self) -> Result<usize, JobSchedulerError>;
+}

--- a/scheduler/src/core/service/cleanupservice.rs
+++ b/scheduler/src/core/service/cleanupservice.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tracing::debug;
+
+use crate::core::{
+    domain::errors::JobSchedulerError,
+    ports::{periodic_task::PeriodicTask, token_cleaner::TokenCleaner},
+};
+
+/// Service logic for cleaning up expired refresh tokens.
+pub struct CleanupService {
+    cleaner: Arc<dyn TokenCleaner>,
+}
+
+impl CleanupService {
+    pub fn new(cleaner: Arc<dyn TokenCleaner>) -> Self {
+        Self { cleaner }
+    }
+}
+
+#[async_trait]
+impl PeriodicTask for CleanupService {
+    async fn run(&self) -> Result<(), JobSchedulerError> {
+        debug!("deleting expired refresh tokens");
+        let count = self.cleaner.delete_expired_tokens().await?;
+        debug!("deleted {} expired refresh tokens", count);
+        Ok(())
+    }
+}

--- a/scheduler/src/core/service/mod.rs
+++ b/scheduler/src/core/service/mod.rs
@@ -1,1 +1,2 @@
+pub mod cleanupservice;
 pub mod schedulerservice;

--- a/scheduler/src/core/service/schedulerservice.rs
+++ b/scheduler/src/core/service/schedulerservice.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use gen_proto_types::{job::v1::Job, job_types::v1::JobType};
 use nanoid::nanoid;
 use tracing::{debug, error};
 
 use crate::core::{
     domain::{errors::JobSchedulerError, type_mapper::JobFromDatabaseJob},
-    ports::{job_fetcher::JobFetcher, publisher::Publisher},
+    ports::{job_fetcher::JobFetcher, periodic_task::PeriodicTask, publisher::Publisher},
 };
 
 /// Service logic for fetching jobs and publishing them.
@@ -72,6 +73,13 @@ impl SchedulerService {
         batch_tracker.wait().await;
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl PeriodicTask for SchedulerService {
+    async fn run(&self) -> Result<(), JobSchedulerError> {
+        SchedulerService::run(self).await
     }
 }
 

--- a/scheduler/src/main.rs
+++ b/scheduler/src/main.rs
@@ -5,9 +5,15 @@ use config::{PostgresConfig, RabbitMQConfig};
 use scheduler::{
     adapters::{
         inbound::ticker::SchedulerTicker,
-        outbound::{postgres::PostgresFetcher, rabbitmq::RabbitMQPublisher},
+        outbound::{
+            postgres::PostgresFetcher, postgres_token_cleaner::PostgresTokenCleaner,
+            rabbitmq::RabbitMQPublisher,
+        },
     },
-    core::{ports::ticker::Ticker, service::schedulerservice::SchedulerService},
+    core::{
+        ports::ticker::Ticker,
+        service::{cleanupservice::CleanupService, schedulerservice::SchedulerService},
+    },
     telemetry,
 };
 use tokio::signal::unix::SignalKind;
@@ -48,30 +54,54 @@ async fn main() -> Result<()> {
         .await
         .context("while setting up rabbitmq publisher schema")?;
 
-    debug!("initializing service");
-    let service = SchedulerService::new(fetcher, publisher.clone());
+    debug!("initializing scheduler service");
+    let scheduler_service = Arc::from(SchedulerService::new(fetcher, publisher.clone()));
 
-    debug!("initializing ticker");
-    let ticker = SchedulerTicker::new(
-        Arc::from(service),
+    debug!("initializing scheduler ticker");
+    let scheduler_ticker = SchedulerTicker::new(
+        scheduler_service,
         Duration::from_secs(1),
         shutdown_token.clone(),
     );
 
-    info!("adapters and service setup completed");
+    debug!("initializing postgres token cleaner");
+    let token_cleaner = Arc::from(
+        PostgresTokenCleaner::new(&db_config.connection_url())
+            .context("while initializing postgres token cleaner")?,
+    );
 
-    debug!("starting ticker in own task");
-    let mut ticker_handle = tokio::spawn(async move {
-        ticker.start().await;
+    debug!("initializing cleanup service");
+    let cleanup_service = Arc::from(CleanupService::new(token_cleaner));
+
+    debug!("initializing cleanup ticker");
+    let cleanup_ticker = SchedulerTicker::new(
+        cleanup_service,
+        Duration::from_secs(60 * 60),
+        shutdown_token.clone(),
+    );
+
+    info!("adapters and services setup completed");
+
+    debug!("starting scheduler ticker in own task");
+    let mut scheduler_handle = tokio::spawn(async move {
+        scheduler_ticker.start().await;
     });
 
-    info!("ticker started");
+    debug!("starting cleanup ticker in own task");
+    let mut cleanup_handle = tokio::spawn(async move {
+        cleanup_ticker.start().await;
+    });
+
+    info!("tickers started");
 
     let mut sigterm = tokio::signal::unix::signal(SignalKind::terminate())?;
 
     tokio::select! {
-        _ = &mut ticker_handle => {
-            warn!("ticker exited prematurely");
+        _ = &mut scheduler_handle => {
+            warn!("scheduler ticker exited prematurely");
+        }
+        _ = &mut cleanup_handle => {
+            warn!("cleanup ticker exited prematurely");
         }
         _ = tokio::signal::ctrl_c() => {
             info!("received ctrl-c. exiting scheduler");
@@ -84,7 +114,8 @@ async fn main() -> Result<()> {
     info!("exiting scheduler");
     shutdown_token.cancel();
 
-    let _ = ticker_handle.await;
+    let _ = scheduler_handle.await;
+    let _ = cleanup_handle.await;
 
     publisher.close();
     // Do not remove. Publisher close requires some millis for closing connections


### PR DESCRIPTION
Closes #115 
Depends on #73 

Adds a cleanup cron job that deletes expired refresh tokens from the DB every hour