### PR TITLE
refactor(ui): move localStorage store access to client:only component

### DIFF
--- a/frontend/web/src/components/LocalStorageHandler.svelte
+++ b/frontend/web/src/components/LocalStorageHandler.svelte
@@ -1,0 +1,34 @@
+<!--
+	@component
+	Client-only component which persists global stores to localStorage
+	and reads their values on load.
+ -->
+
+<script lang="ts">
+	import settings from '@/stores/settings.svelte';
+	import { onMount } from 'svelte';
+	import type { Writable } from 'svelte/store';
+
+	const localStorageStores = [
+		{
+			key: 'settings',
+			store: settings,
+		},
+	];
+
+	onMount(() => {
+		localStorageStores.forEach(x => configureStore(x));
+	});
+
+	const configureStore = (store: { key: string; store: Writable<any> }) => {
+		// set initial saved state
+		const dataString = localStorage.getItem(store.key);
+
+		if (dataString) store.store.set(JSON.parse(dataString));
+
+		// update localStorage on every store update
+		store.store.subscribe(x => {
+			localStorage.setItem(store.key, JSON.stringify(x));
+		});
+	};
+</script>

--- a/frontend/web/src/layout/PageLayout.astro
+++ b/frontend/web/src/layout/PageLayout.astro
@@ -1,4 +1,5 @@
 ---
+import LocalStorageHandler from '@/components/LocalStorageHandler.svelte';
 import Alerts from '@/components/shared/Alerts.svelte';
 import Footer from '@/components/shared/Footer.astro';
 import Navbar from '@/components/shared/Navbar.astro';
@@ -34,5 +35,6 @@ interface Props {
 
 	<Alerts client:load />
 
-	<ThemeHandler client:only />
+	<ThemeHandler client:load />
+	<LocalStorageHandler client:only />
 </html>

--- a/frontend/web/src/pages/account.astro
+++ b/frontend/web/src/pages/account.astro
@@ -50,8 +50,7 @@ import { KeySquareIcon, UserIcon } from '@lucide/svelte';
 		<section>
 			<h2 class="text-lg font-bold">Settings</h2>
 
-			{/* settings involves calls to localStorage, hence client-only */}
-			<SettingsForm client:only />
+			<SettingsForm client:load />
 		</section>
 	</main>
 </PageLayout>

--- a/frontend/web/src/stores/settings.svelte.ts
+++ b/frontend/web/src/stores/settings.svelte.ts
@@ -1,25 +1,5 @@
 import { writable } from 'svelte/store';
 
-const SETTINGS_LOCAL_STORAGE_KEY = 'settings';
-
 const settings = writable<{ theme?: '' | 'dark' | 'light' }>({});
 
-// set initial saved state
-setSettingsFromLocalStorage();
-
-// update localStorage on every settings update
-settings.subscribe(x => {
-	if (!localStorage) return;
-
-	localStorage.setItem(SETTINGS_LOCAL_STORAGE_KEY, JSON.stringify(x));
-});
-
 export default settings;
-
-function setSettingsFromLocalStorage() {
-	if (!localStorage) return;
-
-	const settingsString = localStorage.getItem(SETTINGS_LOCAL_STORAGE_KEY);
-
-	if (settingsString) settings.set(JSON.parse(settingsString));
-}


### PR DESCRIPTION
Move `localStorage` access to `client:only` component which only handles these reads/writes. Thereby, store reads with default values are valid in prerendering.