### PR TITLE
fix(nix): add missing rust-src extension

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
         system:
         let
           pkgs = nixpkgsFor.${system};
-          rustStableToolchain = pkgs.rust-bin.stable.latest.minimal.override {
+          rustStableToolchain = pkgs.rust-bin.stable.latest.default.override {
             extensions = [ "rust-src" ];
           };
           rustNightlyToolchain = pkgs.rust-bin.nightly.latest.minimal.override {


### PR DESCRIPTION
The `rust-analyzer` extension stopped working after rust was added to the flake.
Usually `rust-analyzer` can get `rust-src` itself via `rustup` but as we have our `rust` environment in the flake, the extension needs to be provided by us