### PR TITLE
fix: include UTC timezone in API timestamps

### DIFF
--- a/api-service/src/core/models/job/mod.rs
+++ b/api-service/src/core/models/job/mod.rs
@@ -1,4 +1,4 @@
-use chrono::{Duration, NaiveDateTime};
+use chrono::{DateTime, Duration, NaiveDateTime, Utc};
 use database_client::{
     models::{Job, JobDetailsHttp, JobDetailsPing},
     schema::job,
@@ -53,7 +53,7 @@ pub struct DisplayJob {
     pub notify_users: bool,
     pub custom_notification: Option<String>,
     pub run_every: Duration,
-    pub last_scheduled: Option<NaiveDateTime>,
+    pub last_scheduled: Option<DateTime<Utc>>,
     pub details: DisplayJobDetails,
 }
 
@@ -78,7 +78,7 @@ pub struct UpdateRequestJob {
     pub notify_users: Option<bool>,
     pub custom_notification: Option<String>,
     pub run_every: Option<Duration>,
-    pub last_scheduled: Option<NaiveDateTime>,
+    pub last_scheduled: Option<DateTime<Utc>>,
     pub details: Option<UpdateRequestJobDetails>,
 }
 
@@ -103,6 +103,21 @@ pub struct UpdateJob {
     pub custom_notification: Option<String>,
     pub run_every: Option<Duration>,
     pub last_scheduled: Option<NaiveDateTime>,
+}
+
+impl From<UpdateRequestJob> for UpdateJob {
+    fn from(value: UpdateRequestJob) -> Self {
+        Self {
+            id: value.id,
+            name: value.name,
+            job_type_id: value.job_type_id,
+            group_id: value.group_id,
+            notify_users: value.notify_users,
+            custom_notification: value.custom_notification,
+            run_every: value.run_every,
+            last_scheduled: value.last_scheduled.map(|dt| dt.naive_utc()),
+        }
+    }
 }
 
 impl From<CreateJob> for Job {
@@ -130,7 +145,7 @@ impl From<Job> for DisplayJob {
             notify_users: value.notify_users,
             custom_notification: value.custom_notification,
             run_every: value.run_every,
-            last_scheduled: value.last_scheduled,
+            last_scheduled: value.last_scheduled.map(|dt| dt.and_utc()),
             details: DisplayJobDetails::Undefined,
         }
     }

--- a/api-service/src/core/models/job/run.rs
+++ b/api-service/src/core/models/job/run.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDateTime;
+use chrono::{DateTime, NaiveDateTime, Utc};
 use database_client::models::JobRun;
 use frunk::LabelledGeneric;
 use serde::{Deserialize, Serialize};
@@ -13,7 +13,7 @@ use crate::core::models::job::{
 pub struct DisplayJobRun {
     pub id: String,
     pub job_id: String,
-    pub timestamp: NaiveDateTime,
+    pub timestamp: DateTime<Utc>,
     pub triggered_notification: bool,
     pub batch_id: String,
     pub reachable: bool,
@@ -36,7 +36,7 @@ impl From<JobRun> for DisplayJobRun {
         Self {
             id: value.id,
             job_id: value.job_id,
-            timestamp: value.timestamp,
+            timestamp: value.timestamp.and_utc(),
             triggered_notification: value.triggered_notification,
             batch_id: value.batch_id,
             reachable: value.reachable,

--- a/api-service/src/core/services/jobs/mod.rs
+++ b/api-service/src/core/services/jobs/mod.rs
@@ -6,7 +6,7 @@ use crate::core::{
     models::{
         auth::UserId,
         job::{
-            CreateJob, CreateJobDetails, DisplayJob, DisplayJobDetails, UpdateRequestJob,
+            CreateJob, CreateJobDetails, DisplayJob, DisplayJobDetails, UpdateJob, UpdateRequestJob,
             UpdateRequestJobDetails, http::detail::CreateJobDetailsHttp,
             ping::detail::CreateJobDetailsPing,
         },
@@ -96,7 +96,7 @@ impl ServiceJobPort for Service {
 
         let job = self
             .db
-            .update_job(job_id, updated_job.clone().transmogrify())?;
+            .update_job(job_id, UpdateJob::from(updated_job.clone()))?;
 
         let detail = match updated_job.details {
             Some(detail) => match detail {


### PR DESCRIPTION
## Summary
- serialize job timestamps as `DateTime<Utc>` so JSON includes the trailing `Z`
- convert job `last_scheduled` and run timestamps to UTC on output
- ensure update payloads convert back to naive timestamps for storage

## Rationale
- fixes issue #181 where frontend misinterprets UTC datetimes without a timezone designator

## Changes
- api-service/core models now expose `DateTime<Utc>` for returned job/run timestamps
- mapper adjusts run and job timestamps between DB naive values and UTC

Fixes #181